### PR TITLE
Fix: Remove dangling pointer in conf.c

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -140,6 +140,7 @@ static int conf_handler(void *user, const char *section, const char *key,
 
 void conf_init(void) {
     const char *loaded_path = NULL;
+    char path[CONF_PATH_SIZE];
 
     // load ini from local working directory
     if (ini_parse(CONF_PATH_CWD, conf_handler, conf_tuples) >= 0)
@@ -149,7 +150,6 @@ void conf_init(void) {
     if (loaded_path == NULL) {
         const char *home = getenv("HOME");
         if (home) {
-            char path[CONF_PATH_SIZE];
             (void)snprintf(path, CONF_PATH_SIZE, "%s/%s", home, CONF_PATH_HOME);
             if (ini_parse(path, conf_handler, conf_tuples) >= 0)
                 loaded_path = path;


### PR DESCRIPTION
Compiling in release mod leads to `Dangling pointer ‘loaded_path’ to ‘path’ may be used`

Moving path variable declaration fixes the issue.