### PR TITLE
Update container image to build libs documentation.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: giomba/ceda-cemu-builder:1
+      image: giomba/ceda-cemu-builder:2
       options: --user root
     steps:
       - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ function(add_ceda_target target)
         target_compile_options(${target} PRIVATE -Werror)
     elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
         target_compile_options(${target} PRIVATE -DDEBUG=1)
-        # set(Z80_WITH_HTML_DOCUMENTATION YES)
     endif()
 
     target_link_libraries(${target}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y
 RUN apt install -y git cmake gcc g++ clang-tidy clang-format libsdl2-dev libsdl2-mixer-dev
 RUN apt install -y meson ninja-build libffi-dev libgit2-dev
+RUN apt install -y doxygen sphinx python3-breathe
 
 RUN git clone https://github.com/Snaipe/Criterion.git && cd Criterion && git checkout master && meson build && meson install -C build
 

--- a/script/docker
+++ b/script/docker
@@ -12,5 +12,5 @@ docker run --rm -ti -u builder \
     -v "$(pwd)":/home/builder/workspace \
     -v /tmp:/tmp \
     -w /home/builder/workspace \
-    giomba/ceda-cemu-builder:1 \
+    giomba/ceda-cemu-builder:2 \
     "$@"


### PR DESCRIPTION
I think that the title is self-explanatory.
I moved the set(Z80...) variable before the include of the library, because it is needed to build the docs.
This changes the previous behaviour (docs are always built, instead of only being built when building in debug mode, and the build output is very verbose), but this doesn't look like a big issues, since CMake is smart enough to only build it the first time.