### PR TITLE
Add support for custom peripherals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CORE_SRCS
     src/time.c
     src/timer.c
     src/tokenizer.c
+    src/ubus.c
     src/upd8255.c
     src/video.c
     src/ram/auxram.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CORE_SRCS
     src/int.c
     src/keyboard.c
     src/main.c
+    src/charmon.c
     src/serial.c
     src/sio2.c
     src/speaker.c

--- a/conf/ceda-cemu.ini
+++ b/conf/ceda-cemu.ini
@@ -15,6 +15,10 @@
 # See: https://github.com/GLGPrograms/ceda-img
 cge_installed = true
 
+# Character Device Monitor, write-only
+# Virtual peripheral to log via stdout on the emulator
+charmon_installed = false
+
 [path]
 
 # Custom path for BIOS ROM, else default is used

--- a/src/bus.c
+++ b/src/bus.c
@@ -10,6 +10,7 @@
 #include "sio2.h"
 #include "speaker.h"
 #include "timer.h"
+#include "ubus.h"
 #include "upd8255.h"
 #include "video.h"
 
@@ -120,7 +121,7 @@ uint8_t bus_io_in(ceda_ioaddr_t address) {
         }
     }
 
-    return 0;
+    return ubus_io_in(address);
 }
 
 void bus_io_out(ceda_ioaddr_t _address, uint8_t value) {
@@ -136,6 +137,8 @@ void bus_io_out(ceda_ioaddr_t _address, uint8_t value) {
             }
         }
     }
+
+    ubus_io_out(address, value);
 }
 
 void bus_init(CEDAModule *mod) {

--- a/src/ceda.c
+++ b/src/ceda.c
@@ -1,5 +1,6 @@
 #include "ceda.h"
 
+// computer core
 #include "bios.h"
 #include "bus.h"
 #include "cli.h"
@@ -14,8 +15,12 @@
 #include "serial.h"
 #include "sio2.h"
 #include "speaker.h"
+#include "ubus.h"
 #include "upd8255.h"
 #include "video.h"
+
+// user peripherals
+#include "charmon.h"
 
 #include <assert.h>
 #include <unistd.h>
@@ -32,10 +37,12 @@ static CEDAModule mod_speaker;
 static CEDAModule mod_sio2;
 static CEDAModule mod_int;
 static CEDAModule mod_serial;
+static CEDAModule mod_ubus;
+static CEDAModule mod_charmon;
 
 static CEDAModule *modules[] = {
-    &mod_bios,  &mod_cli,     &mod_gui, &mod_bus,    &mod_cpu,
-    &mod_video, &mod_speaker, &mod_int, &mod_serial, &mod_sio2,
+    &mod_bios,    &mod_cli, &mod_gui,    &mod_bus,  &mod_cpu,  &mod_video,
+    &mod_speaker, &mod_int, &mod_serial, &mod_sio2, &mod_ubus, &mod_charmon,
 };
 
 void ceda_init(void) {
@@ -48,6 +55,8 @@ void ceda_init(void) {
     rom_bios_init(&mod_bios);
     video_init(&mod_video);
     speaker_init(&mod_speaker);
+    ubus_init(&mod_ubus);
+    charmon_init(&mod_charmon);
     bus_init(&mod_bus);
     cpu_init(&mod_cpu);
     int_init(&mod_int);

--- a/src/charmon.c
+++ b/src/charmon.c
@@ -1,0 +1,26 @@
+#include "charmon.h"
+
+#include "conf.h"
+#include "ubus.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define CHARMON_BASE (0xF0)
+
+void charmon_out(ceda_ioaddr_t address, uint8_t value) {
+    (void)address;
+    (void)putc(value, stdout);
+}
+
+void charmon_init(CEDAModule *mod) {
+    memset(mod, 0, sizeof(*mod));
+
+    bool *conf_installed = conf_getBool("mod", "charmon_installed");
+    bool installed = conf_installed ? *conf_installed : false;
+
+    if (!installed)
+        return;
+
+    ubus_register(CHARMON_BASE, CHARMON_BASE + 1, NULL, charmon_out);
+}

--- a/src/charmon.h
+++ b/src/charmon.h
@@ -1,0 +1,10 @@
+#ifndef CEDA_CHAR_MONITOR_H
+#define CEDA_CHAR_MONITOR_H
+
+#include "module.h"
+#include "type.h"
+
+void charmon_init(CEDAModule *mod);
+void charmon_out(ceda_ioaddr_t address, uint8_t value);
+
+#endif // CEDA_CHAR_MONITOR_H

--- a/src/conf.c
+++ b/src/conf.c
@@ -23,6 +23,7 @@ static const char *CONF_PATH_HOME =
 // Emulator dynamic configuration
 static struct {
     bool cge_installed;
+    bool charmon_installed;
     ceda_string_t *bios_rom_path;
     ceda_string_t *char_rom_path;
     ceda_string_t *cge_rom_path;
@@ -46,6 +47,7 @@ typedef struct conf_tuple_t {
 
 static conf_tuple_t conf_tuples[] = {
     {"mod", "cge_installed", CONF_BOOL, &conf.cge_installed},
+    {"mod", "charmon_installed", CONF_BOOL, &conf.charmon_installed},
     {"path", "bios_rom", CONF_STR, &conf.bios_rom_path},
     {"path", "char_rom", CONF_STR, &conf.char_rom_path},
     {"path", "cge_rom", CONF_STR, &conf.cge_rom_path},

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -45,13 +45,8 @@ bool ubus_register(ceda_ioaddr_t base, uint32_t top, ubus_io_read_t read,
     // check if peripherals are overlapping
     for (size_t i = 0; i < ubus_used; ++i) {
         struct ubus_io_slot *slot = &ubus_slots[i];
-        if (slot->base >= base && slot->base < top)
-            return false;
-        if (slot->top <= top && slot->top > base)
-            return false;
-        if (slot->base < base && slot->top > top)
-            return false;
-        if (slot->base > base && slot->top < top)
+        bool ok = (top <= slot->base) || (base >= slot->top);
+        if (!ok)
             return false;
     }
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -1,0 +1,88 @@
+#include "ubus.h"
+
+#include "conf.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#define UBUS_MAX_PERIPHERALS (4)
+
+#define LOG_LEVEL LOG_LVL_INFO
+#include "log.h"
+
+struct ubus_io_slot {
+    ceda_ioaddr_t base;
+    uint32_t top;
+    ubus_io_read_t in;
+    ubus_io_write_t out;
+};
+
+static struct ubus_io_slot ubus_slots[UBUS_MAX_PERIPHERALS];
+static size_t ubus_used = 0;
+
+void ubus_init(CEDAModule *mod) {
+    memset(mod, 0, sizeof(*mod));
+
+    mod->init = ubus_init;
+}
+
+bool ubus_register(ceda_ioaddr_t base, uint32_t top, ubus_io_read_t read,
+                   ubus_io_write_t write) {
+    if (!read && !write)
+        return false;
+
+    if (top > 0x100)
+        return false;
+
+    if (top <= base)
+        return false;
+
+    if (ubus_used == UBUS_MAX_PERIPHERALS) {
+        LOG_WARN("Too many peripherals registered\n");
+        return false;
+    }
+
+    // check if peripherals are overlapping
+    for (size_t i = 0; i < ubus_used; ++i) {
+        struct ubus_io_slot *slot = &ubus_slots[i];
+        if (slot->base >= base && slot->base < top)
+            return false;
+        if (slot->top <= top && slot->top > base)
+            return false;
+        if (slot->base < base && slot->top > top)
+            return false;
+        if (slot->base > base && slot->top < top)
+            return false;
+    }
+
+    ubus_slots[ubus_used].base = base;
+    ubus_slots[ubus_used].top = top;
+    ubus_slots[ubus_used].in = read;
+    ubus_slots[ubus_used].out = write;
+    ubus_used += 1;
+
+    LOG_INFO("Registered peripheral at %02x\n", (unsigned int)base);
+
+    return true;
+}
+
+zuint8 ubus_io_in(ceda_ioaddr_t address) {
+    for (size_t i = 0; i < ubus_used; ++i) {
+        struct ubus_io_slot *slot = &ubus_slots[i];
+        if (address >= slot->base && address < slot->top)
+            if (slot->in)
+                return slot->in(address - slot->base);
+    }
+    return 0;
+}
+
+void ubus_io_out(ceda_ioaddr_t address, uint8_t value) {
+    for (size_t i = 0; i < ubus_used; ++i) {
+        struct ubus_io_slot *slot = &ubus_slots[i];
+        if (address >= slot->base && address < slot->top)
+            if (slot->out) {
+                slot->out(address - slot->base, value);
+                return;
+            }
+    }
+}

--- a/src/ubus.h
+++ b/src/ubus.h
@@ -1,0 +1,37 @@
+#ifndef CEDA_USER_BUS_H
+#define CEDA_USER_BUS_H
+
+#include "module.h"
+#include "type.h"
+
+#include <stdbool.h>
+
+#include <Z80.h>
+
+typedef uint8_t (*ubus_io_read_t)(ceda_ioaddr_t address);
+typedef void (*ubus_io_write_t)(ceda_ioaddr_t address, uint8_t value);
+
+/**
+ * @brief Initialize the User Bus module.
+ *
+ * This module allows users to connect custom peripherals to the computer bus.
+ */
+void ubus_init(CEDAModule *mod);
+
+/**
+ * @brief Register a peripheral on the bus.
+ *
+ * @param base Peripheral base address.
+ * @param top Peripheral top address + 1 (eg. the first unused address)
+ * @param read IO input callback.
+ * @param write IO output callback.
+ *
+ * @return true in case of success, false otherwise.
+ */
+bool ubus_register(ceda_ioaddr_t base, uint32_t top, ubus_io_read_t read,
+                   ubus_io_write_t write);
+
+zuint8 ubus_io_in(ceda_ioaddr_t address);
+void ubus_io_out(ceda_ioaddr_t address, uint8_t value);
+
+#endif // CEDA_USER_BUS_H


### PR DESCRIPTION
This branch implements a dynamic bus module, which can be used to register custom peripherals to the computer's bus.
The idea is that the standard configuration of the computer is statically described in the bus array in `bus.c`.
When a peripheral is not found in the main bus, then it is searched via the `ubus.c` module.
The `ubus.c` module contains a small array where an user can register its own peripherals at runtime, by calling `ubus_register()` and providing the necessary address range and callbacks for I/O.
(Obviously this is not how it works on the real hardware, but it looks a reasonable way to implement user-built peripherals in the emulator, by separating the vanilla bus from the customized one)

Then, this branch also implements a `charmon.c` fake write-only character based device: at the moment, it can be used by the emulated software to log data on the emulator's stdout, and also acts as an example of how to properly implement a custom peripheral module. (note the dynamic configuration via the user's conf file)

Eventually, the `ubus.c` module can also be used to implement the actual hardware mods that we are planning.